### PR TITLE
Support output from SimpleCov::Formatter::JSONFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ This will read in `coverage/.resultset.json` from RSpec and produce `coverage.js
 }
 ```
 
+## SimpleCov JSON Formatter
+
+While this works, without configuration, with the `.resultset.json` file that SimpleCov internally produces, this has a number of issues:
+1. It's an internal format and subject to change.
+2. It doesn't take into account `:nocov:` blocks that `SimpleCov::LinesClassifier` would remove.
+
+So it is better to configure the `SimpleCov::Formatter::JSONFormatter` that SimpleCov comes bundled with. To use, set the following in your `spec_helper.rb` file:
+
+```ruby
+require "simplecov_json_formatter"
+
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::JSONFormatter
+]
+```
+
+... and change your action to:
+```yaml
+    - uses: madleech/coverage-converter-simplecov
+      with:
+        coverage-file: "**/coverage.json"
+```
+
 ## Combining Multiple Resultsets
 
 If you're using something like [Knapsack](https://github.com/KnapsackPro/knapsack) to run your test suite in parallel, you'll likely end up with multiple `.resultset.json` files which need combining. While Simplecov does have some hidden functionality for merging multiple coverage files, this action can handle it automatically:

--- a/src/logic.js
+++ b/src/logic.js
@@ -63,6 +63,12 @@ function flattenRuns(inputs) {
   const flattenedCoverage = [];
 
   for (const data of inputs) {
+    if (isFromJsonFormatter(data)) {
+      const lines = replaceIgnoredWithNull(convertFormat(data)); // {<file>: [lines]}
+      flattenedCoverage.push(lines);
+      continue;
+    }
+
     // format is {<suite name>: {"coverage": {<file>: {lines: [lines]}}}}
     for (const singleRunCoverageData of Object.values(data)) {
       flattenedCoverage.push(convertFormat(singleRunCoverageData));
@@ -72,11 +78,29 @@ function flattenRuns(inputs) {
   return flattenedCoverage;
 }
 
+// determine if the coverage file was produced by SimpleCov::Formatter::JSONFormatter, or is the
+// internal .resultset.json file that SimpleCov always produces. They have different formats.
+//
+// SimpleCov::Formatter::JSONFormatter has "meta" and "coverage" keys at the top level
+function isFromJsonFormatter(input) {
+  return !!input.meta && !!input.coverage;
+}
+
 // convert from {"coverage": {<file>: {"lines": [lines]}}}} to {<file>: [lines]}
 function convertFormat(input) {
   const output = {};
   for (const [file, coverage] of Object.entries(input.coverage)) {
     output[file] = coverage.lines;
+  }
+  return output;
+}
+
+// SimpleCov::Formatter::JSONFormatter uses "ignored" to indicate that a line was not covered, but we use null for that.
+// replace "ignored" with null
+function replaceIgnoredWithNull(input) {
+  const output = {};
+  for (const [file, lines] of Object.entries(input)) {
+    output[file] = lines.map((line) => line === "ignored" ? null : line);
   }
   return output;
 }
@@ -139,4 +163,4 @@ function write(output) {
   return path;
 }
 
-module.exports = {run, expand, read, flattenRuns, convertFormat, combine, sum, merge, removePrefixes, write}
+module.exports = {run, expand, read, flattenRuns, isFromJsonFormatter, convertFormat, replaceIgnoredWithNull, combine, sum, merge, removePrefixes, write}


### PR DESCRIPTION
While this works, without configuration, with the `.resultset.json` file that SimpleCov internally produces, this has a number of issues:
1. It's an internal format and subject to change.
2. It doesn't take into account `:nocov:` blocks that `SimpleCov::LinesClassifier` would remove.

So it is better to configure the `SimpleCov::Formatter::JSONFormatter` as the output formatter, however it produces a slightly different format so we need to adapt this action to handle the differences.